### PR TITLE
 Request object in application

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "rafi"
-version = "0.1.2"
+version = "0.2.0"
 description = "A tiny route dispatcher for Google Cloud Functions."
 authors = ["Danilo Braband <dbraband@gmail.com>"]
 license = "MIT"

--- a/rafi/__init__.py
+++ b/rafi/__init__.py
@@ -1,3 +1,3 @@
 from rafi.app import App
 
-__version__ = "0.1.2"
+__version__ = "0.2.0"

--- a/rafi/app.py
+++ b/rafi/app.py
@@ -8,6 +8,7 @@ class App(object):
         self.app_name = app_name
         self.log = logging.getLogger(self.app_name)
         self.routes = defaultdict(dict)
+        self.request = None
 
     def route(self, path, methods=["GET"]):
         def decorator(f):
@@ -40,6 +41,7 @@ class App(object):
             if request.method not in self.routes[regex]:
                 return "", 405
 
+            self.request = request
             res = self.routes[regex][request.method](**match.groupdict())
             if isinstance(res, tuple):
                 return res

--- a/tests/test_rafi.py
+++ b/tests/test_rafi.py
@@ -21,7 +21,11 @@ def app():
 
     @demo.route("/code/<code>")
     def code(code=200):
-        return ("code: {}".format(code), code)
+        return "code: {}".format(code), code
+
+    @demo.route("/query")
+    def query():
+        return demo.request.args.get("query")
 
     return demo
 
@@ -78,4 +82,11 @@ def test_empty_path(app, req):
         flask.request.path = ""
         res = app(flask.request)
         assert res[0] == "index"
+        assert res[1] == 200
+
+
+def test_request_object(app, req):
+    with req.test_request_context(path="/query?query=1234"):
+        res = app(flask.request)
+        assert res[0] == "1234"
         assert res[1] == 200


### PR DESCRIPTION
Makes the request object available in application. Example app:

~~~ python
app = rafi.App("demo_app")

@app.route("/hello/<name>")
def index(name):
    # request object is available in app.request
    return f"hello {name}"
~~~